### PR TITLE
Added folder to ignore so backup files won't sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 .DS_Store
 .DS_Store?
 _notes/
+_originals/
 ._*
 .Spotlight-V100
 .Trashes


### PR DESCRIPTION
Folder name "_originals" was added to gitignore to stop my local backup
files to be synced to the master repo